### PR TITLE
Feature: Add progress parameter to Scrobbler methods

### DIFF
--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -457,16 +457,22 @@ class Scrobbler(object):
         if self.progress > 0:
             self.start()
 
-    def start(self):
+    def start(self, progress=None):
         """Start scrobbling this :class:`Scrobbler`'s *media* object"""
+        if progress is not None:
+            self.progress = progress
         return self._post('scrobble/start')
 
-    def pause(self):
+    def pause(self, progress=None):
         """Pause the scrobbling of this :class:`Scrobbler`'s *media* object"""
+        if progress is not None:
+            self.progress = progress
         return self._post('scrobble/pause')
 
-    def stop(self):
+    def stop(self, progress=None):
         """Stop the scrobbling of this :class:`Scrobbler`'s *media* object"""
+        if progress is not None:
+            self.progress = progress
         return self._post('scrobble/stop')
 
     def finish(self):


### PR DESCRIPTION
Improve https://github.com/moogar0880/PyTrakt/pull/196.

This allows the caller to pass progress value in the same go.

I would not want to call `update(progress)` before calling `stop()` just to get accurate progress, because that would make two API calls to trakt.tv.

Required by:
- https://github.com/Taxel/PlexTraktSync/pull/1131