### PR TITLE
add show_id to TVEpisode

### DIFF
--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -81,7 +81,8 @@ class Calendar(object):
                 'show_data': TVShow(**show_data)
             }
             self._calendar.append(
-                TVEpisode(show_data['title'], season, ep_num, **e_data)
+                TVEpisode(show_data['title'], season, ep_num,
+                          show_id=show_data['trakt'], **e_data)
             )
         self._calendar = sorted(self._calendar, key=lambda x: x.airs_at)
 

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -336,7 +336,9 @@ def get_watchlist(list_type=None, sort=None):
             from trakt.tv import TVEpisode
             show = d.pop('show')
             extract_ids(d['episode'])
-            results.append(TVEpisode(show.get('title', None), **d['episode']))
+            results.append(TVEpisode(show.get('title', None),
+                                     show_id=show.get('trakt', None),
+                                     **d['episode']))
         elif 'movie' in d:
             from trakt.movies import Movie
             results.append(Movie(**d.pop('movie')))

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -439,7 +439,8 @@ class TVShow(object):
                 # Prepare episodes
                 episodes = []
                 for ep in season.pop('episodes', []):
-                    episode = TVEpisode(show=self.title, **ep)
+                    episode = TVEpisode(show=self.title,
+                                        show_id=self.trakt, **ep)
                     episodes.append(episode)
                 season['episodes'] = episodes
 
@@ -456,7 +457,8 @@ class TVShow(object):
         """
         if self._last_episode is None:
             data = yield self.ext + '/last_episode?extended=full'
-            self._last_episode = data and TVEpisode(show=self.title, **data)
+            self._last_episode = data and TVEpisode(show=self.title,
+                                                    show_id=self.trakt, **data)
         yield self._last_episode
 
     @property
@@ -467,7 +469,8 @@ class TVShow(object):
         """
         if self._next_episode is None:
             data = yield self.ext + '/next_episode?extended=full'
-            self._next_episode = data and TVEpisode(show=self.title, **data)
+            self._next_episode = data and TVEpisode(show=self.title,
+                                                    show_id=self.trakt, **data)
         yield self._next_episode
 
     @property

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -147,7 +147,8 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                 show_data = item.pop('show')
                 extract_ids(show_data)
                 episode = TVEpisode(show_data['title'], item_data['season'],
-                                    item_data['number'])
+                                    item_data['number'],
+                                    show_id=show_data['trakt'])
                 self._items.append(episode)
             elif item_type == 'person':
                 self._items.append(Person(item_data['name'],
@@ -439,7 +440,8 @@ class User(object):
             ep_data = data.pop('episode')
             extract_ids(ep_data)
             sh_data = data.pop('show')
-            ep_data.update(data, show=sh_data.get('title'))
+            ep_data.update(data, show=sh_data.get('title'),
+                           show_id=sh_data.get('trakt'))
             yield TVEpisode(**ep_data)
 
     @staticmethod


### PR DESCRIPTION
follow dece4d0a1b453412f9e7f92a938232487977bffd

Actually, to get the show of a **TVEpisode** we only have show name (`self.show`) which is not reliable because some shows have the same name.
The show trakt id is more reliable than show name because it is unique. This PR adds `show_id` attribute to **TVEpisode**.

__Example :__  [Top Boy](https://trakt.tv/shows/top-boy) and [Top Boy 2019](https://trakt.tv/shows/top-boy-2019)
A TVEpisode from [Top Boy 2019](https://trakt.tv/shows/top-boy-2019) uses slug `top-boy` (made from `slugify(self.show)` ) instead of `top-boy-2019` to fetch data from trakt api. Therefore data received is wrong.