### PR TITLE
Initialize Movie.trakt property with None

### DIFF
--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -94,7 +94,7 @@ class Movie:
             self.slug = slug or slugify(self.title)
 
         self.released = self.tmdb_id = self.imdb_id = self.duration = None
-        self.trakt_id = self.tagline = self.overview = self.runtime = None
+        self.trakt = self.trakt_id = self.tagline = self.overview = self.runtime = None
         self.updated_at = self.trailer = self.homepage = self.rating = None
         self.votes = self.language = self.available_translations = None
         self.genres = self.certification = None


### PR DESCRIPTION
Various calls to `extract_ids` create the `trakt` property. Add the initializing to IDE typing would not consider property unknown.

For example:
- https://github.com/Taxel/PlexTraktSync/blob/88dc3fd97e603f73316d5bd393bce9f7447aeb94/plextraktsync/sync.py#L119

Relates to some older bug report:
- https://github.com/moogar0880/PyTrakt/issues/158