### PR TITLE
Fix ids setter for Person and TVEpisode

### DIFF
--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -67,6 +67,14 @@ def test_get_people():
     for group in groups:
         assert all([isinstance(p, Person) for p in group])
 
+    ids = {
+        'imdb': 'nm0227759',
+        'slug': 'peter-dinklage',
+        'tmdb': 22970,
+        'trakt': 639,
+    }
+    assert got.people[0].ids['ids'] == ids
+
 
 def test_ratings():
     got = TVShow('Game of Thrones')

--- a/trakt/mixins.py
+++ b/trakt/mixins.py
@@ -28,6 +28,10 @@ class IdsMixin:
             'ids': ids
         }
 
+    @ids.setter
+    def ids(self, value):
+        self._ids = value
+
     @property
     def imdb(self):
         return self._ids.get('imdb', None)


### PR DESCRIPTION
Fix https://github.com/glensc/python-pytrakt/pull/14

`Person` and `TVSeason` `_build` methods are different, they call `ids` first before `_ids`, so therefore we need setter for `ids`. Unfortunately, that data is not even tested, so this did not come out in any way.

Typically it's like this:
- https://github.com/glensc/python-pytrakt/blob/b5dfbeb86b9cad87dd8b9781a3ab9873cf503a6d/trakt/movies.py#L125-L131

but `Person` and `TVSeason` have:
- https://github.com/glensc/python-pytrakt/blob/b5dfbeb86b9cad87dd8b9781a3ab9873cf503a6d/trakt/people.py#L64-L70
- https://github.com/glensc/python-pytrakt/blob/b5dfbeb86b9cad87dd8b9781a3ab9873cf503a6d/trakt/people.py#L64-L70