### PR TITLE
Expose x-error-message header via error_message property

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -108,6 +108,10 @@ class TraktInternalException(TraktException):
     http_code = 500
     message = 'Internal Server Error'
 
+    @property
+    def error_message(self):
+        return self.response.headers.get("x-error-message", None)
+
 
 class TraktBadGateway(TraktException):
     """TraktException type to be raised when a 502 error is raised"""


### PR DESCRIPTION
This gives 500 error right now:
- https://api-v2launch.trakt.tv/shows/game-of-thrones?extended=full

```
HTTP/2 500
date: Mon, 12 Dec 2022 05:38:15 GMT
content-type: text/html
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-download-options: noopen
x-permitted-cross-domain-policies: none
referrer-policy: strict-origin-when-cross-origin
cache-control: no-cache, no-store
x-error-message: Internal server error. Please open a support issue and include your full API request and response, including all headers.
vary: Accept-Encoding
x-request-id: cbb03120-fdbe-46ba-b7e9-1311c7359474
x-runtime: 0.004596
cf-cache-status: BYPASS
server: cloudflare
cf-ray: 77841cdccebac7f7-TLL
```

expose the `x-error-message` header value via `e.error_message`.