### PR TITLE
Refactor: show_collection: Pass all data to TVShow()

### DIFF
--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -201,22 +201,31 @@ def anticipated_shows(page=1, limit=10, extended=None):
 class TVShow(IdsMixin):
     """A Class representing a TV Show object."""
 
-    def __init__(self, title='', slug=None, **kwargs):
+    def __init__(self, title='', slug=None, seasons=None, **kwargs):
         super().__init__()
         self.media_type = 'shows'
         self.top_watchers = self.top_episodes = self.year = None
         self.genres = self.certification = self.network = None
         self._aliases = self._comments = None
         self._images = self._people = self._ratings = self._translations = None
-        self._seasons = None
         self._last_episode = self._next_episode = None
         self._slug = slug
         self.title = title
+        self._seasons = self._build_seasons(seasons) if seasons else None
 
         if len(kwargs) > 0:
             self._build(kwargs)
         else:
             self._get()
+
+    def _build_seasons(self, seasons_data):
+        seasons = []
+        show_id = self.trakt
+        for season_data in seasons_data:
+            number = season_data.pop('number')
+            season = TVSeason(show=self.title, season=number, show_id=show_id, **season_data)
+            seasons.append(season)
+        return seasons
 
     @property
     def slug(self):

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -567,19 +567,28 @@ class TVShow(IdsMixin):
 class TVSeason(IdsMixin):
     """Container for TV Seasons"""
 
-    def __init__(self, show, season=1, slug=None, show_id=None, **kwargs):
+    def __init__(self, show, season=1, slug=None, episodes=None, show_id=None, **kwargs):
         super().__init__()
         self.show = show
         self.show_id = show_id
         self.season = season
         self.slug = slug or slugify(show)
-        self._episodes = self._comments = self._ratings = None
-        self.ext = 'shows/{id}/seasons/{season}'.format(id=self.slug,
-                                                        season=season)
-        if len(kwargs) > 0:
+        self.ext = 'shows/{id}/seasons/{season}'.format(id=self.slug, season=season)
+        self._comments = self._ratings = None
+        self._episodes = self._build_episodes(episodes) if episodes else None
+
+        if len(kwargs) > 0 or episodes:
             self._build(kwargs)
         else:
             self._get()
+
+    def _build_episodes(self, episodes_data):
+        episodes = []
+        for episode_data in episodes_data:
+            season = episode_data.get('season', self.season)
+            episode = TVEpisode(show=self.show, season=season, show_id=self.show_id, **episode_data)
+            episodes.append(episode)
+        return episodes
 
     @get
     def _get(self):

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -558,9 +558,10 @@ class TVShow(IdsMixin):
 class TVSeason(IdsMixin):
     """Container for TV Seasons"""
 
-    def __init__(self, show, season=1, slug=None, **kwargs):
+    def __init__(self, show, season=1, slug=None, show_id=None, **kwargs):
         super().__init__()
         self.show = show
+        self.show_id = show_id
         self.season = season
         self.slug = slug or slugify(show)
         self._episodes = self._comments = self._ratings = None

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -433,10 +433,11 @@ class TVShow(IdsMixin):
                     episode = TVEpisode(show=self.title,
                                         show_id=self.trakt, **ep)
                     episodes.append(episode)
-                season['episodes'] = episodes
 
                 number = season.pop('number')
                 season = TVSeason(self.title, number, self.slug, **season)
+                season._episodes = episodes
+
                 self._seasons.append(season)
 
         yield self._seasons

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -373,10 +373,6 @@ class User:
             for show_data in data:
                 show_item = show_data.pop('show')
                 show = TVShow(**show_item)
-                show._seasons = [
-                    TVSeason(show=show.title, season=sea['number'], **sea)
-                    for sea in show_data.pop('seasons')
-                ]
                 self._show_collection.append(show)
         yield self._show_collection
 

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -370,13 +370,14 @@ class User:
             ext = 'users/{username}/collection/shows?extended=metadata'
             data = yield ext.format(username=slugify(self.username))
             self._show_collection = []
-            for show in data:
-                s = show.pop('show')
-                sh = TVShow(**s)
-                sh._seasons = [TVSeason(show=sh.title,
-                               season=sea['number'], **sea)
-                               for sea in show.pop('seasons')]
-                self._show_collection.append(sh)
+            for show_data in data:
+                show_item = show_data.pop('show')
+                show = TVShow(**show_item)
+                show._seasons = [
+                    TVSeason(show=show.title, season=sea['number'], **sea)
+                    for sea in show_data.pop('seasons')
+                ]
+                self._show_collection.append(show)
         yield self._show_collection
 
     @property


### PR DESCRIPTION
Let `TVShow` handle creating `TVSeason`, which will create `TVSeason` which will create ` TVEpisode` objects themselves rather than building them "outside".

This fixes issue that `show_collection[].seasons[].episode` is raw json rather `TVEpisode` object.

Required for https://github.com/Taxel/PlexTraktSync/pull/1377