### PR TITLE
Refactor: Replace NamedTuple with dataclasses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 deprecated~=1.2.13
 requests-oauthlib>=1.3
 requests>=2.25
+dataclasses; python_version<"3.7"

--- a/trakt/mixins.py
+++ b/trakt/mixins.py
@@ -14,8 +14,10 @@ class IdsMixin:
 
     __ids = ['imdb', 'slug', 'tmdb', 'trakt']
 
-    def __init__(self):
-        self._ids = {}
+    def __init__(self, ids=None):
+        if ids is None:
+            ids = {}
+        self._ids = ids
 
     @property
     def ids(self):
@@ -51,3 +53,11 @@ class IdsMixin:
     @property
     def tvrage(self):
         return self._ids.get('tvrage', None)
+
+    @property
+    def slug(self):
+        return self._ids.get('slug', None)
+
+    @slug.setter
+    def slug(self, value):
+        self._ids['slug'] = value

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -64,13 +64,26 @@ def unfollow(user_name):
 
 
 @dataclass
-class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
-                                       'share_link', 'type', 'display_numbers',
-                                       'allow_comments', 'sort_by',
-                                       'sort_how', 'created_at',
-                                       'updated_at', 'item_count',
-                                       'comment_count', 'likes', 'ids',
-                                       'user', 'creator']), IdsMixin):
+class UserList(IdsMixin):
+    name: str
+    description: str
+    privacy: str
+    share_link: str
+    type: str
+    display_numbers: str
+    allow_comments: str
+    sort_by: str
+    sort_how: str
+    created_at: str
+    updated_at: str
+    item_count: str
+    comment_count: str
+    likes: str
+    trakt: str
+    slug: str
+    user: str
+    creator: str
+
     """A list created by a Trakt.tv :class:`User`"""
 
     def __init__(self, *args, ids=None, **kwargs):

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Interfaces to all of the User objects offered by the Trakt.tv API"""
 from collections import namedtuple
+from dataclasses import dataclass
 
 from trakt.core import delete, get, post
 from trakt.mixins import IdsMixin
@@ -62,6 +63,7 @@ def unfollow(user_name):
     yield 'users/{username}/follow'.format(username=slugify(user_name))
 
 
+@dataclass
 class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                                        'share_link', 'type', 'display_numbers',
                                        'allow_comments', 'sort_by',


### PR DESCRIPTION
Thought that NamedTuple has limitations:
- https://github.com/glensc/python-pytrakt/pull/28

but apparently, `@dataclass` has them as well.