### PR TITLE
Fix: Do not set deleted items to UserList._items in UserList.remove_items()

### DIFF
--- a/trakt/users.py
+++ b/trakt/users.py
@@ -191,7 +191,6 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
         movies = [m.ids for m in items if isinstance(m, Movie)]
         shows = [s.ids for s in items if isinstance(s, TVShow)]
         people = [p.ids for p in items if isinstance(p, Person)]
-        self._items = items
         args = {'movies': movies, 'shows': shows, 'people': people}
         uri = 'users/{user}/lists/{id}/items/remove'.format(
             user=slugify(self.creator), id=self.trakt)


### PR DESCRIPTION
Seems like a bug. Does not make sense to set `_items` to the value of deleted items.

Git blame points to 51b1b7b0 commit: 
```
51b1b7b0 (moogar0880      2015-02-14 22:05:10 -0500 178)         self._items = items
51b1b7b0 (moogar0880      2015-02-14 22:05:10 -0500 205)         self._items = items
```

Seems to me the code is copy-paste from `def add_items(self, *items)`