### PR TITLE
Refactor: Update DataClassMixinClass to pass only defined properties

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 deprecated~=1.2.13
 requests-oauthlib>=1.3
 requests>=2.25
+dataclasses; python_version<"3.7"

--- a/trakt/mixins.py
+++ b/trakt/mixins.py
@@ -3,14 +3,20 @@
 
 __author__ = 'Jon Nappi, Elan Ruusamäe'
 
+from dataclasses import fields
+
 
 def data_class_factory(data_class):
     """
     A Mixin for inheriting @dataclass or NamedTuple, via composition rather inheritance.
     """
+    field_names = set(f.name for f in fields(data_class))
+
     class DataClassMixinClass:
         def __init__(self, **kwargs):
-            self.data = data_class(**kwargs)
+            # https://stackoverflow.com/questions/54678337/how-does-one-ignore-extra-arguments-passed-to-a-dataclass/54678706#54678706
+            values = {k: v for k, v in kwargs.items() if k in field_names}
+            self.data = data_class(**values)
 
         def __getattr__(self, item):
             return getattr(self.data, item)

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Interfaces to all of the User objects offered by the Trakt.tv API"""
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 from trakt.core import delete, get, post
@@ -64,7 +65,8 @@ def unfollow(user_name):
     yield 'users/{username}/follow'.format(username=slugify(user_name))
 
 
-class UserListTuple(NamedTuple):
+@dataclass(frozen=True)
+class UserListEntry:
     name: str
     description: str
     privacy: str
@@ -83,7 +85,7 @@ class UserListTuple(NamedTuple):
     creator: str
 
 
-class UserList(DataClassMixin(UserListTuple), IdsMixin):
+class UserList(DataClassMixin(UserListEntry), IdsMixin):
     """A list created by a Trakt.tv :class:`User`"""
 
     def __init__(self, ids=None, **kwargs):


### PR DESCRIPTION
Improves https://github.com/glensc/python-pytrakt/pull/29

Uses [`@dataclass`](https://docs.python.org/3/library/dataclasses.html) and its valid properties to create `UserList` class.

The other classes should be updated too. Leaving that for the future.