### PR TITLE
Update baseurl

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -28,7 +28,7 @@ __all__ = ['Airs', 'Alias', 'Comment', 'Genre', 'get', 'delete', 'post', 'put',
 
 #: The base url for the Trakt API. Can be modified to run against different
 #: Trakt.tv environments
-BASE_URL = 'https://api-v2launch.trakt.tv/'
+BASE_URL = 'https://api.trakt.tv/'
 
 #: The Trakt.tv OAuth Client ID for your OAuth Application
 CLIENT_ID = None


### PR DESCRIPTION
Updates trakt baseurl because old one is deprecated.

According to [Trakt API](https://twitter.com/traktapi/status/1742976564567106019) :

> The API host name [http://api-v2launch.trakt.tv](https://t.co/9TYHCeYzjb) will be removed on February 1. 
>
>This has been deprecated since 2017. This will only affect very old apps and they need to use [http://api.trakt.tv](https://t.co/0mENbHo7Uq) to continue working beyond February 1.