### PR TITLE
Feature: Add details RateLimitException to parse x-ratelimit header

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -13,6 +13,7 @@ __all__ = [
     'BadResponseException',
 
     # Exceptions by HTTP status code
+    # https://trakt.docs.apiary.io/#introduction/status-codes
     'BadRequestException',
     'OAuthException',
     'ForbiddenException',

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -77,7 +77,7 @@ class NotFoundException(TraktException):
 class MethodNotAllowedException(TraktException):
     """TraktException type to be raised when a 405 return code is received"""
     http_code = 405
-    message = 'Method not Allowed'
+    message = 'Method Not Found - method doesn\'t exist'
 
 
 class ConflictException(TraktException):

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -105,7 +105,7 @@ class RateLimitException(TraktException):
 
     @property
     def retry_after(self):
-        return int(self.response.headers.get("Retry-After", 1))
+        return int(self.response.headers.get("retry-after", 1))
 
     @property
     def details(self):

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -107,6 +107,15 @@ class RateLimitException(TraktException):
     def retry_after(self):
         return int(self.response.headers.get("Retry-After", 1))
 
+    @property
+    def details(self):
+        from json import JSONDecodeError, loads
+
+        try:
+            return loads(self.response.headers.get("x-ratelimit", ""))
+        except JSONDecodeError:
+            return None
+
 
 class TraktInternalException(TraktException):
     """TraktException type to be raised when a 500 error is raised"""


### PR DESCRIPTION
Example:

```py
{'name': 'AUTHED_API_POST_LIMIT', 'period': 1, 'limit': 1, 'remaining': 0, 'until': '2024-01-08T22:31:48Z'}
```