### PR TITLE
Fix: Allow install source with pip/pipenv

### DIFF
--- a/trakt/__version__.py
+++ b/trakt/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "Unknown"
+__version__ = "3.4.0.dev0"


### PR DESCRIPTION
Currently not installable from source because version "Uknown" does not parse.

```
 ✖ pip install "trakt@https://github.com/glensc/python-trakt/archive/refs/tags/3.4.26.zip#egg=trakt" 
Collecting trakt@ https://github.com/glensc/python-trakt/archive/refs/tags/3.4.26.zip#egg=trakt
  Using cached https://github.com/glensc/python-trakt/archive/refs/tags/3.4.26.zip
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [27 lines of output]
      Traceback (most recent call last):
        File "/Users/glen/Library/Caches/glen/direnv/PlexTraktSync/python-3.8/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/glen/Library/Caches/glen/direnv/PlexTraktSync/python-3.8/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Users/glen/Library/Caches/glen/direnv/PlexTraktSync/python-3.8/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 480, in run_setup
          super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 18, in <module>
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 147, in setup
          _setup_distribution = dist = klass(attrs)
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 314, in __init__
          self.metadata.version = self._normalize_version(self.metadata.version)
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 350, in _normalize_version
          normalized = str(Version(version))
        File "/private/var/folders/f1/qj3m1q9507d2_7rnqwfgzyrm0000gp/T/pip-build-env-g683r1ck/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/version.py", line 198, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'Unknown'
```

Refs:
- https://github.com/pypa/pipx/issues/812#issuecomment-1066727490