### PR TITLE
Fix: Remove superluous ":" from iso8601 timestamp

### DIFF
--- a/trakt/utils.py
+++ b/trakt/utils.py
@@ -46,7 +46,7 @@ def now():
 
 def timestamp(date_object):
     """Generate a trakt formatted timestamp from the given date object"""
-    fmt = '%Y-%m-%d:T%H:%M:%S.000Z'
+    fmt = '%Y-%m-%dT%H:%M:%S.000Z'
     return date_object.strftime(fmt)
 
 


### PR DESCRIPTION
Introduced in 6b86097ce87ad384e32842ed178e5e194ccfdcec (Aug 23, 2015)

Spec:
- https://en.wikipedia.org/wiki/ISO_8601