### PR TITLE
Feature: Add sync.get_playback method

### DIFF
--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -12,7 +12,7 @@ from trakt.utils import slugify, timestamp
 
 __author__ = 'Jon Nappi'
 __all__ = ['Scrobbler', 'comment', 'rate', 'add_to_history', 'get_collection',
-           'PlaybackEntry',
+           'PlaybackEntry', 'get_playback',
            'get_watchlist', 'add_to_watchlist', 'remove_from_history',
            'remove_from_watchlist', 'add_to_collection',
            'remove_from_collection', 'search', 'search_by_id', 'checkin_media',
@@ -337,6 +337,28 @@ def search_by_id(query, id_type='imdb', media_type=None, slugify_query=False):
             results.append(Person(**d.pop('person')))
     yield results
 
+
+@get
+def get_playback(list_type=None):
+    """
+    Get playback progress.
+
+    Whenever a scrobble is paused, the playback progress is saved. Use this
+    progress to sync up playback across different media centers or apps.
+
+    For example, you can start watching a movie in a media center, stop it,
+    then resume on your tablet from the same spot. Each item will have the
+    progress percentage between 0 and 100.
+
+    You can optionally specify a type to only get movies or episodes.
+
+    By default, all results will be returned.
+
+    Pagination is optional and can be used for something like an "on deck"
+    feature, or if you only need a limited data set.
+
+    https://trakt.docs.apiary.io/#reference/sync/playback/get-playback-progress
+    """
 
 @get
 def get_watchlist(list_type=None, sort=None):

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -359,6 +359,27 @@ def get_playback(list_type=None):
 
     https://trakt.docs.apiary.io/#reference/sync/playback/get-playback-progress
     """
+    valid_type = ("movies", "episodes")
+
+    if list_type and list_type not in valid_type:
+        raise ValueError(f"Invalid list_type: {list_type}. Must be one of {valid_type}")
+
+    uri = "sync/playback"
+    if list_type:
+        uri += f"/{list_type}"
+
+    items = yield uri
+    results = []
+    for item in items:
+        if "type" not in item:
+            continue
+        data = item.pop(item["type"])
+        if "show" in item:
+            data["show"] = item.pop("show")
+        results.append(PlaybackEntry(**item, data=data))
+
+    yield results
+
 
 @get
 def get_watchlist(list_type=None, sort=None):

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -8,6 +8,7 @@ from typing import Any
 from deprecated import deprecated
 
 from trakt.core import delete, get, post
+from trakt.mixins import IdsMixin
 from trakt.utils import slugify, timestamp
 
 __author__ = 'Jon Nappi'
@@ -20,13 +21,17 @@ __all__ = ['Scrobbler', 'comment', 'rate', 'add_to_history', 'get_collection',
 
 
 @dataclass(frozen=True)
-class PlaybackEntry:
+class PlaybackEntry(IdsMixin):
     progress: float
     paused_at: str
     id: int
     type: str
     # data for "type" structure
     data: Any
+
+    @property
+    def _ids(self):
+        return self.data["ids"]
 
 
 @post

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """This module contains Trakt.tv sync endpoint support functions"""
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Any
 
 from deprecated import deprecated
 
@@ -10,10 +12,21 @@ from trakt.utils import slugify, timestamp
 
 __author__ = 'Jon Nappi'
 __all__ = ['Scrobbler', 'comment', 'rate', 'add_to_history', 'get_collection',
+           'PlaybackEntry',
            'get_watchlist', 'add_to_watchlist', 'remove_from_history',
            'remove_from_watchlist', 'add_to_collection',
            'remove_from_collection', 'search', 'search_by_id', 'checkin_media',
            'delete_checkin']
+
+
+@dataclass(frozen=True)
+class PlaybackEntry:
+    progress: float
+    paused_at: str
+    id: int
+    type: str
+    # data for "type" structure
+    data: Any
 
 
 @post


### PR DESCRIPTION
https://trakt.docs.apiary.io/#reference/sync/playback/get-playback-progress

required by:
- https://github.com/Taxel/PlexTraktSync/pull/1889

Not implemented:
- `start_at`, `end_at` parameters
- unit testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a feature to track and synchronize playback progress for movies or episodes across different media centers or applications.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->