### PR TITLE
Store OAuth global variables on initial auth

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -179,7 +179,7 @@ def oauth_auth(username, client_id=None, client_secret=None, store=False,
         PIN. Default function `_terminal_oauth_pin` for terminal auth
     :return: Your OAuth access token
     """
-    global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN
+    global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_REFRESH, OAUTH_EXPIRES_AT
     if client_id is None and client_secret is None:
         client_id, client_secret = _get_client_info()
     CLIENT_ID, CLIENT_SECRET = client_id, client_secret
@@ -259,7 +259,7 @@ def get_device_token(device_code, client_id=None, client_secret=None,
     :return: Information regarding the authentication polling.
     :return type: dict
     """
-    global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_REFRESH
+    global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_REFRESH, OAUTH_EXPIRES_AT
     if client_id is None and client_secret is None:
         client_id, client_secret = _get_client_info()
     CLIENT_ID, CLIENT_SECRET = client_id, client_secret


### PR DESCRIPTION
I noticed when setting up my own OAuth config storage that fetching the values of `core.OAUTH_REFRESH` and `core.OAUTH_EXPIRES_AT` after running `trakt.init` wasn't working. Turns out that's because while they were being set, they were only being set locally. I made them global in `oauth_auth()` and `get_device_token()` and it's working now.