### PR TITLE
Fix: Skip sending trakt-api-key with None value

### DIFF
--- a/trakt/api.py
+++ b/trakt/api.py
@@ -191,10 +191,12 @@ class TokenAuth(AuthBase):
 
         [client_id, client_token] = self.get_token()
 
-        r.headers.update({
-            'trakt-api-key': client_id,
-            'Authorization': f'Bearer {client_token}',
-        })
+        if client_id and client_token:
+            r.headers.update({
+                'trakt-api-key': client_id,
+                'Authorization': f'Bearer {client_token}',
+            })
+
         return r
 
     def get_token(self):

--- a/trakt/api.py
+++ b/trakt/api.py
@@ -196,6 +196,8 @@ class TokenAuth(AuthBase):
                 'trakt-api-key': client_id,
                 'Authorization': f'Bearer {client_token}',
             })
+        else:
+            self.logger.debug("Skipping auth headers: missing credentials")
 
         return r
 


### PR DESCRIPTION
This would result http/client error:
> TypeError: expected string or bytes-like object

Example:

<details>

```
self = <urllib3.connection.HTTPSConnection object at 0x7f90e856e5e0>
header = b'trakt-api-key', values = [None], i = 0, one_value = None

    def putheader(self, header, *values):
        """Send a request header line to the server.
    
        For example: h.putheader('Accept', 'text/html')
        """
        if self.__state != _CS_REQ_STARTED:
            raise CannotSendHeader()
    
        if hasattr(header, 'encode'):
            header = header.encode('ascii')
    
        if not _is_legal_header_name(header):
            raise ValueError('Invalid header name %r' % (header,))
    
        values = list(values)
        for i, one_value in enumerate(values):
            if hasattr(one_value, 'encode'):
                values[i] = one_value.encode('latin-1')
            elif isinstance(one_value, int):
                values[i] = str(one_value).encode('ascii')
    
>           if _is_illegal_header_value(values[i]):
E           TypeError: expected string or bytes-like object

/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/http/client.py:1262: TypeError

```

</details>



- https://github.com/Taxel/PlexTraktSync/actions/runs/13010226328/job/36315881347?pr=2165