### PR TITLE
Reduce access_token refresh margin delay from 2 days to 10 minutes

### DIFF
--- a/trakt/api.py
+++ b/trakt/api.py
@@ -214,7 +214,7 @@ class TokenAuth(AuthBase):
 
         current = datetime.now(tz=timezone.utc)
         expires_at = datetime.fromtimestamp(self.config.OAUTH_EXPIRES_AT, tz=timezone.utc)
-        if expires_at - current > timedelta(days=2):
+        if expires_at - current > timedelta(minutes=10):
             self.OAUTH_TOKEN_VALID = True
         else:
             self.refresh_token()


### PR DESCRIPTION
Starting on March 4, 2025, a Trakt OAuth `access_token` will expire in 24 hours, instead of 3 months.

The current logic is to refresh the `access_token` if its expiration date is within next 2 days.
With current code, a 24h token would be immediately refreshed after being fetched. We do not want that.
This PR changes this delay from 2 days to 10 minutes.

>Why 10 minutes ?

This is a margin to be sure the token does not expire in the middle of a critical action such as a list sync/fetch/post.
It could be any other delay, but not bigger than 24h.

Refs :
- https://github.com/trakt/api-help/discussions/495