### PR TITLE
Log error when refresh token fails

### DIFF
--- a/trakt/api.py
+++ b/trakt/api.py
@@ -253,8 +253,8 @@ class TokenAuth(AuthBase):
             error = e.response.json().get("error") if e.response is not None else "No error description"
             error_description = e.response.json().get("error_description") if e.response is not None else ""
             self.logger.error(
-                "{} - Unable to refresh expired OAuth token ".format(e.http_code) +
-                "({}) {}".format(error, error_description)
+                "%s - Unable to refresh expired OAuth token (%s) %s",
+                e.http_code, error, error_description
             )
             return
 

--- a/trakt/api.py
+++ b/trakt/api.py
@@ -250,8 +250,16 @@ class TokenAuth(AuthBase):
             response = self.client.post('oauth/token', data)
             self.refresh_attempts = 0
         except (OAuthException, BadRequestException) as e:
-            error = e.response.json().get("error") if e.response is not None else "No error description"
-            error_description = e.response.json().get("error_description") if e.response is not None else ""
+            if e.response is not None:
+                try:
+                    error = e.response.json().get("error")
+                    error_description = e.response.json().get("error_description")
+                except JSONDecodeError:
+                    error = "Invalid JSON response"
+                    error_description = e.response.text
+            else:
+                error = "No error description"
+                error_description = ""
             self.logger.error(
                 "%s - Unable to refresh expired OAuth token (%s) %s",
                 e.http_code, error, error_description


### PR DESCRIPTION
Refresh token can fail with error 400 or error 401 for many reasons, not only invalid _refresh_token_.
If refresh fails, an error should be logged.
And response body provides useful information.

## Example in PlexTraktSync 
Before PR:
```
INFO     OAuth token has expired, refreshing now...
CRITICAL Error running sync command: Trakt authentication error: Unauthorized - OAuth must be provided
```

After PR:
```
INFO     OAuth token has expired, refreshing now...
ERROR    401 - Unable to refresh expired OAuth token (invalid_client) Client authentication failed due to unknown
         client, no client authentication included, or unsupported authentication method.
CRITICAL Error running sync command: Trakt authentication error: Unauthorized - OAuth must be provided
```
```
INFO     OAuth token has expired, refreshing now...
ERROR    400 - Unable to refresh expired OAuth token (invalid_grant) The provided authorization grant is invalid,
         expired, revoked, does not match the redirection URI used in the authorization request, or was issued to
         another client.
CRITICAL Error running sync command: Trakt authentication error: Unauthorized - OAuth must be provided
```

See : 
- https://github.com/Taxel/PlexTraktSync/issues/2268