### PR TITLE
CI: Switch ubuntu-20.04 with ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Python ${{ matrix.python }}
     strategy:
       matrix:


### PR DESCRIPTION
See https://github.com/glensc/python-pytrakt/pull/81#issuecomment-3067059207

Drops 3.6 testing:
> Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.

To find matching Python versions:

```sh
curl -O https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
cat versions-manifest.json | jq '.[] | select(.files[]? | select(.platform == "linux" and .platform_version == "22.04")) | .version' -r
```